### PR TITLE
mostly fixing typos (as I see them)

### DIFF
--- a/sections/checklists.md
+++ b/sections/checklists.md
@@ -25,7 +25,7 @@ instance of `YarnConfiguration`.
 
 [ ] Are tested against a secure cluster from a logged in user.
 
-[ ] Are tested against a securer cluste from a not logged in user, and the program set up to
+[ ] Are tested against a secure cluster from a not logged in user, and the program set up to
 use a keytab (if supported).
 
 [ ] Are tested from a logged out user with a token file containing the tokens and the environment variable

--- a/sections/hdfs.md
+++ b/sections/hdfs.md
@@ -100,7 +100,7 @@ authenticated HTTP connections, which works *provided all clients are all runnin
 
 See [Secure DataNode](http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-common/SecureMode.html#Secure_DataNode)
 
-## HDFS Boostrap
+## HDFS Bootstrap
 
 1. NN reads in a keytab and initializes itself from there (i.e. no need to `kinit`; ticket
 renewal handed by `UGI`).

--- a/sections/what_is_kerberos.md
+++ b/sections/what_is_kerberos.md
@@ -56,7 +56,7 @@ can act as a federated KDC infrastructure. Hadoop cluster management tools often
 aid in setting up a KDC for a Hadoop cluster. 
 There's even a minature one, the `MiniKDC` in the Hadoop source for [testing](testing.html).
 
-KDCs are managed by operations teams. If a developer finds themselves mainting a KDC outside
+KDCs are managed by operations teams. If a developer finds themselves maintaining a KDC outside
 of a test environment, they are in trouble and probably out of their depth.
 
 ## Kerberos Principal
@@ -81,7 +81,7 @@ CPU load on the server). Even a small Hadoop cluster could generate enough authe
 requests on a cluster restart for this to happen —hence a different principal for every
 service on every node.
 
-How do the Hadoop services know which principal to identify themselves at. Generally,
+How do the Hadoop services know which principal to identify themselves at? Generally,
 though Hadoop configuration files. They also determine the hostname, and use this to
 decide which of the possible principals in their keytab (see below) to identify themselves
 at. For this to work, machines have to know who they are.
@@ -220,7 +220,7 @@ using that ticket. That recipient only has the permissions granted to the ticket
 also provided), and those permissions are only valid for as long as the ticket
 is valid.
 
-The limited lifetime iftickets ensure that even if a ticket is captured by a malicious
+The limited lifetime of tickets ensures that even if a ticket is captured by a malicious
 attacker, they can only make use of the credential for the lifetime of the ticket.
 The ops team doesn't need to worry about lost/stolen tickets, to have a process for
 revoking them, as they expire within a short time period, usually a couple of days.

--- a/sections/what_is_kerberos.md
+++ b/sections/what_is_kerberos.md
@@ -293,7 +293,7 @@ which is stored in the client's *Credentials Cache*. A call to `klist` can be us
 
 Then, they must run a hadoop command
 
-    hadoop fs --ls /
+    hadoop fs -ls /
 
 1. The HDFS client code attempts to talk to the HDFS Namenode via the
 `org.apache.hadoop.hdfs.protocol.ClientProtocol` IPC protocol


### PR DESCRIPTION
Hi Steve and all,

the only thing "critical" thing I wanted to fix was the "hadoop fs --ls /" command, since it would produce an error when typed/pasted.

Not sure if it's a typo, or intentional, but have also replaced a "." with a "?" in: sections/what_is_kerberos.md (commit dc161b4)
> How do the Hadoop services know which principal to identify themselves at? Generally,

Hope it helps,
Camypaj